### PR TITLE
Add mempool transaction lookup by txid and multi-address transaction history endpoint

### DIFF
--- a/app/address/router.py
+++ b/app/address/router.py
@@ -1,4 +1,5 @@
 from app.utils import pagination, paginated_response
+from .schemas import AddressTransactionsMultiArgs
 from sqlalchemy.ext.asyncio import AsyncSession
 from fastapi import APIRouter, Depends
 from app.dependencies import get_page
@@ -15,7 +16,27 @@ from app.schemas import (
 router = APIRouter(prefix="/address", tags=["Addresses"])
 
 
-@router.get("/{address}/outputs/{currency}", response_model=OutputPaginatedResponse)
+@router.post("/transactions", response_model=TransactionPaginatedResponse)
+async def list_transactions_multi(
+    args: AddressTransactionsMultiArgs,
+    session: AsyncSession = Depends(get_session),
+    page: int = Depends(get_page),
+):
+    limit, offset = pagination(page)
+
+    total = await service.count_transactions_multi(
+        session, args.addresses, args.currency
+    )
+    items = await service.list_transactions_multi(
+        session, args.addresses, args.currency, limit, offset
+    )
+
+    return paginated_response(items, total, page, limit)
+
+
+@router.get(
+    "/{address}/outputs/{currency}", response_model=OutputPaginatedResponse
+)
 async def get_unspent_outputs(
     address: str,
     currency: str,
@@ -47,12 +68,16 @@ async def get_utxo(
     limit, offset = pagination(page)
 
     total = await service.count_utxo(session, address, currency, amount)
-    items = await service.list_utxo(session, address, currency, amount, limit, offset)
+    items = await service.list_utxo(
+        session, address, currency, amount, limit, offset
+    )
 
     return paginated_response(items.all(), total, page, limit)
 
 
-@router.get("/{address}/transactions", response_model=TransactionPaginatedResponse)
+@router.get(
+    "/{address}/transactions", response_model=TransactionPaginatedResponse
+)
 async def get_transactions(
     address: str,
     session: AsyncSession = Depends(get_session),
@@ -67,7 +92,8 @@ async def get_transactions(
 
 
 @router.get(
-    "/{address}/transactions/{ticker}", response_model=TransactionPaginatedResponse
+    "/{address}/transactions/{ticker}",
+    response_model=TransactionPaginatedResponse,
 )
 async def list_transactions_ticker(
     address: str,
@@ -78,7 +104,9 @@ async def list_transactions_ticker(
     limit, offset = pagination(page)
 
     total = await service.count_transactions(session, address, ticker)
-    items = await service.list_transactions(session, address, limit, offset, ticker)
+    items = await service.list_transactions(
+        session, address, limit, offset, ticker
+    )
 
     return paginated_response(items, total, page, limit)
 

--- a/app/address/schemas.py
+++ b/app/address/schemas.py
@@ -1,0 +1,6 @@
+from app.schemas import CustomModel
+
+
+class AddressTransactionsMultiArgs(CustomModel):
+    addresses: list[str]
+    currency: str | None = None

--- a/app/address/service.py
+++ b/app/address/service.py
@@ -1,18 +1,24 @@
-from app.models import Output, Transaction, AddressBalance, Address, MemPool
+import typing
+
 from sqlalchemy import Select, select, func, ScalarResult
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models import Output, Transaction, AddressBalance, Address, MemPool
+from app.blocks.service import get_latest_block
+
 from app.transactions.service import (
+    load_mempool_tx_details,
     load_tx_details,
     get_token_units,
-    load_mempool_tx_details,
 )
-from sqlalchemy.ext.asyncio import AsyncSession
-from app.blocks.service import get_latest_block
+
+S = typing.TypeVar("S", bound=tuple[typing.Any, ...])
 
 
 def unspent_outputs_filters(query: Select, address: str, currency) -> Select:
     query = query.filter(
         Output.address == address,
-        func.lower(Output.currency) == currency.lower(),  # type: ignore
+        func.lower(Output.currency) == currency.lower(),
         ~Output.spent,
     )
 
@@ -23,7 +29,9 @@ async def count_unspent_outputs(
     session: AsyncSession, address: str, currency: str
 ) -> int:
     return await session.scalar(
-        unspent_outputs_filters(select(func.count(Output.id)), address, currency)
+        unspent_outputs_filters(
+            select(func.count(Output.id)), address, currency
+        )
     )
 
 
@@ -36,7 +44,10 @@ async def list_unspent_outputs(
 ) -> ScalarResult[Output]:
     return await session.scalars(
         unspent_outputs_filters(
-            select(Output).order_by(Output.amount.desc()).limit(limit).offset(offset),
+            select(Output)
+            .order_by(Output.amount.desc())
+            .limit(limit)
+            .offset(offset),
             address,
             currency,
         )
@@ -47,11 +58,15 @@ def utxo_cte(address: str, currency: str):
     return (
         select(
             Output,
-            func.sum(Output.amount)  # type: ignore
+            func.sum(Output.amount)
             .over(order_by=Output.blockhash)
             .label("cumulative_amount"),
         )
-        .filter(Output.address == address, Output.currency == currency, ~Output.spent)
+        .filter(
+            Output.address == address,
+            Output.currency == currency,
+            ~Output.spent,
+        )
         .cte("cumulative_outputs")
     )
 
@@ -61,7 +76,9 @@ async def count_utxo(
 ) -> int:
     cte = utxo_cte(address, currency)
     query = (
-        select(func.count(1)).select_from(cte).where(cte.c.cumulative_amount < amount)
+        select(func.count(1))
+        .select_from(cte)
+        .where(cte.c.cumulative_amount < amount)
     )
     return await session.scalar(query) or 0
 
@@ -86,9 +103,20 @@ async def list_utxo(
 
 
 def transactions_filters(
-    query: Select, address: str, currency: str | None = None
-) -> Select:
+    query: Select[S], address: str, currency: str | None = None
+) -> Select[S]:
     query = query.filter(Transaction.addresses.contains([address]))
+
+    if currency is not None:
+        query = query.filter(Transaction.currencies.contains([currency]))
+
+    return query
+
+
+def transactions_filters_multi(
+    query: Select[S], addresses: list[str], currency: str | None
+) -> Select[S]:
+    query = query.filter(Transaction.addresses.overlap(addresses))
 
     if currency is not None:
         query = query.filter(Transaction.currencies.contains([currency]))
@@ -100,7 +128,19 @@ async def count_transactions(
     session: AsyncSession, address: str, currency: str | None = None
 ):
     return await session.scalar(
-        transactions_filters(select(func.count(Transaction.id)), address, currency)
+        transactions_filters(
+            select(func.count(Transaction.id)), address, currency
+        )
+    )
+
+
+async def count_transactions_multi(
+    session: AsyncSession, addresses: list[str], currency: str | None
+) -> int:
+    return await session.scalar(
+        transactions_filters_multi(
+            select(func.count(Transaction.id)), addresses, currency
+        )
     )
 
 
@@ -123,33 +163,67 @@ async def list_transactions(
             currency,
         )
     ):
-        transactions.append(await load_tx_details(session, transaction, latest_block))
+        transactions.append(
+            await load_tx_details(session, transaction, latest_block)
+        )
 
     return transactions
 
 
-async def list_balances(session: AsyncSession, address: str) -> list[AddressBalance]:
+async def list_transactions_multi(
+    session: AsyncSession,
+    addresses: list[str],
+    currency: str | None,
+    limit: int,
+    offset: int,
+) -> list[Transaction]:
+    latest_block = await get_latest_block(session)
+    transactions = []
+    for transaction in await session.scalars(
+        transactions_filters_multi(
+            select(Transaction)
+            .order_by(Transaction.created.desc())
+            .limit(limit)
+            .offset(offset),
+            addresses,
+            currency,
+        )
+    ):
+        transactions.append(
+            await load_tx_details(session, transaction, latest_block)
+        )
+
+    return transactions
+
+
+async def list_balances(
+    session: AsyncSession, address: str
+) -> list[AddressBalance]:
     balances = []
     for balance in await session.scalars(
         select(AddressBalance).filter(
             AddressBalance.address_id == Address.id, Address.address == address
         )
     ):
-        balance.units = await get_token_units(session, balance.currency)
+        balance.units = await get_token_units(session, balance.currency)  # ty:ignore[unresolved-attribute]
 
         balances.append(balance)
 
     return balances
 
 
-async def list_address_mempool_transactions(session: AsyncSession, address: str):
+async def list_address_mempool_transactions(
+    session: AsyncSession, address: str
+):
     mempool = await session.scalar(select(MemPool).limit(1))
 
     if mempool is None:
         return []
 
     return [
-        await load_mempool_tx_details(session, transaction, mempool.raw["outputs"])
+        await load_mempool_tx_details(
+            session, transaction, mempool.raw["outputs"]
+        )
         for transaction in mempool.raw["transactions"]
         if address in transaction["addresses"]
     ]

--- a/app/transactions/dependencies.py
+++ b/app/transactions/dependencies.py
@@ -1,8 +1,7 @@
 from sqlalchemy.ext.asyncio import AsyncSession
-from fastapi import Depends
-
 from app.database import get_session
 from app.errors import Abort
+from fastapi import Depends
 from . import service
 
 
@@ -10,6 +9,9 @@ async def require_transaction(
     txid: str, session: AsyncSession = Depends(get_session)
 ):
     transaction = await service.get_transaction_by_txid(session, txid)
+
+    if not transaction:
+        transaction = await service.get_mempool_transaction_by_txid(session, txid)
 
     if not transaction:
         raise Abort("transactions", "not-found")

--- a/app/transactions/router.py
+++ b/app/transactions/router.py
@@ -1,10 +1,9 @@
-from starlette.responses import JSONResponse
-
 from app.schemas import TransactionPaginatedResponse, TransactionResponse
 from app.utils import pagination, paginated_response
 from sqlalchemy.ext.asyncio import AsyncSession
 from .dependencies import require_transaction
 from .schemas import TransactionBroadcastArgs
+from starlette.responses import JSONResponse
 from fastapi import APIRouter, Depends
 from app.dependencies import get_page
 from app.database import get_session
@@ -49,7 +48,7 @@ async def get_transaction_info(
     return transaction
 
 
-@router.post("/broadcast")
+@router.post("/broadcast", response_model=str)
 async def broadcast_transaction(
     transaction: TransactionBroadcastArgs,
 ):

--- a/app/transactions/service.py
+++ b/app/transactions/service.py
@@ -1,12 +1,11 @@
-from decimal import Decimal
-import typing
-
 from app.models import Transaction, Output, Input, Block, Token, MemPool
 from sqlalchemy.ext.asyncio import AsyncSession
 from app.blocks.service import get_latest_block
 from sqlalchemy import select, Select, func
 from app.parser import make_request
 from app import get_settings
+from decimal import Decimal
+import typing
 
 S = typing.TypeVar("S", bound=tuple[typing.Any, ...])
 
@@ -184,6 +183,26 @@ async def load_mempool_tx_details(
             transaction["fee"] += input_["amount"]
 
     return transaction
+
+
+async def get_mempool_transaction_by_txid(
+    session: AsyncSession,
+    txid: str,
+) -> dict[str, typing.Any] | None:
+    mempool = await session.scalar(select(MemPool).limit(1))
+
+    if mempool is None:
+        return None
+
+    transaction = next(
+        (tx for tx in mempool.raw["transactions"] if tx["txid"] == txid),
+        None,
+    )
+
+    if transaction is None:
+        return None
+
+    return await load_mempool_tx_details(session, transaction, mempool.raw["outputs"])
 
 
 async def get_mempool_transactions(

--- a/app/utils.py
+++ b/app/utils.py
@@ -5,6 +5,9 @@ import math
 
 from app import constants
 
+Limit = typing.NewType("Limit", int)
+Offset = typing.NewType("Offset", int)
+
 
 def utcnow():
     return datetime.now(UTC).replace(tzinfo=None)
@@ -29,11 +32,13 @@ def token_type(name: str):
 
 
 # Helper function for pagination
-def pagination(page: int, size: int = constants.DEFAULT_PAGINATION_SIZE):
+def pagination(
+    page: int, size: int = constants.DEFAULT_PAGINATION_SIZE
+) -> tuple[Limit, Offset]:
     """limit, offset = pagination(:page, :page_size)"""
     offset = (size * page) - size
 
-    return size, offset
+    return size, offset  # type: ignore
 
 
 # Helper function to make pagination dict for api

--- a/tests/address/test_list_address_transactions_multi.py
+++ b/tests/address/test_list_address_transactions_multi.py
@@ -1,0 +1,108 @@
+from tests.client_requests import addresses
+from app.utils import to_satoshi
+from tests import helpers
+import secrets
+
+
+async def test_normal(client, block, address_transaction):
+    response = await addresses.post_address_transactions_multi(
+        client=client,
+        addresses=address_transaction.addresses,
+    )
+    print(response.json())
+    assert response.status_code == 200
+
+    assert response.json()["pagination"] == {"total": 1, "pages": 1, "page": 1}
+
+    transaction_data = response.json()["list"][0]
+
+    assert transaction_data["txid"] == address_transaction.txid
+    assert transaction_data["blockhash"] == address_transaction.blockhash
+    assert transaction_data["height"] == address_transaction.height
+    assert transaction_data["amount"] == {
+        token: to_satoshi(amount)
+        for token, amount in address_transaction.amount.items()
+    }
+
+
+async def test_multiple_addresses(client, block, session):
+    addr1 = secrets.token_hex(20)
+    addr2 = secrets.token_hex(20)
+
+    tx1 = await helpers.create_transaction(session, addresses=[addr1])
+    tx2 = await helpers.create_transaction(session, addresses=[addr2])
+
+    # Each address alone returns only its own transaction
+    response1 = await addresses.post_address_transactions_multi(
+        client=client, addresses=[addr1]
+    )
+    assert response1.json()["pagination"]["total"] == 1
+    assert response1.json()["list"][0]["txid"] == tx1.txid
+
+    response2 = await addresses.post_address_transactions_multi(
+        client=client, addresses=[addr2]
+    )
+    assert response2.json()["pagination"]["total"] == 1
+    assert response2.json()["list"][0]["txid"] == tx2.txid
+
+    # Both addresses together return both transactions
+    response = await addresses.post_address_transactions_multi(
+        client=client, addresses=[addr1, addr2]
+    )
+    print(response.json())
+    assert response.status_code == 200
+    assert response.json()["pagination"] == {"total": 2, "pages": 1, "page": 1}
+
+    txids = {tx["txid"] for tx in response.json()["list"]}
+    assert tx1.txid in txids
+    assert tx2.txid in txids
+
+
+async def test_with_currency(client, block, address_transaction):
+    response = await addresses.post_address_transactions_multi(
+        client=client,
+        addresses=address_transaction.addresses,
+        currency=address_transaction.currencies[0],
+    )
+    print(response.json())
+    assert response.status_code == 200
+
+    assert response.json()["pagination"] == {"total": 1, "pages": 1, "page": 1}
+    assert response.json()["list"][0]["txid"] == address_transaction.txid
+
+
+async def test_with_currency_not_match(client, block, address_transaction):
+    response = await addresses.post_address_transactions_multi(
+        client=client,
+        addresses=address_transaction.addresses,
+        currency="NONEXISTENT",
+    )
+    print(response.json())
+    assert response.status_code == 200
+
+    assert response.json()["pagination"] == {"total": 0, "pages": 0, "page": 1}
+    assert response.json()["list"] == []
+
+
+async def test_no_matching_addresses(client, block):
+    response = await addresses.post_address_transactions_multi(
+        client=client,
+        addresses=["nonexistent_address_1", "nonexistent_address_2"],
+    )
+    print(response.json())
+    assert response.status_code == 200
+
+    assert response.json()["pagination"] == {"total": 0, "pages": 0, "page": 1}
+    assert response.json()["list"] == []
+
+
+async def test_empty_addresses(client, block):
+    response = await addresses.post_address_transactions_multi(
+        client=client,
+        addresses=[],
+    )
+    print(response.json())
+    assert response.status_code == 200
+
+    assert response.json()["pagination"] == {"total": 0, "pages": 0, "page": 1}
+    assert response.json()["list"] == []

--- a/tests/client_requests/addresses.py
+++ b/tests/client_requests/addresses.py
@@ -41,3 +41,19 @@ async def get_address_balances(
     client: TestClient, address: str, page: int = 1
 ) -> Response:
     return await client.get(f"/address/{address}/balances", query_string={"page": page})
+
+
+async def post_address_transactions_multi(
+    client: TestClient,
+    addresses: list[str],
+    currency: str | None = None,
+    page: int = 1,
+) -> Response:
+    body = {"addresses": addresses}
+    if currency is not None:
+        body["currency"] = currency
+    return await client.post(
+        "/address/transactions",
+        json=body,
+        query_string={"page": page},
+    )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,21 +1,19 @@
 # Based on https://praciano.com.br/fastapi-and-async-sqlalchemy-20-with-pytest-done-right.html
 # https://github.com/gpkc/fastapi-sqlalchemy-pytest
 
-from contextlib import ExitStack
-import asyncio
-
-from pytest_postgresql.janitor import DatabaseJanitor
-from async_asgi_testclient import TestClient
-from pytest_postgresql import factories
-from sqlalchemy import make_url, delete
-import pytest
-from sqlalchemy.ext.asyncio import AsyncSession
-
-from app.database import sessionmanager, get_session
-from app.settings import get_settings
 from app.models import Base, Transaction, Block, Address, Output
+from pytest_postgresql.janitor import DatabaseJanitor
+from app.database import sessionmanager, get_session
+from sqlalchemy.ext.asyncio import AsyncSession
+from async_asgi_testclient import TestClient
+from sqlalchemy import make_url, delete
+from pytest_postgresql import factories
+from app.settings import get_settings
+from contextlib import ExitStack
 from app import create_app
 from tests import helpers
+import asyncio
+import pytest
 
 # This is needed to obtain PostgreSQL version
 test_db = factories.postgresql_proc()
@@ -128,6 +126,12 @@ async def address_utxo(session, address) -> Output:
 @pytest.fixture
 async def address_transaction(session, address) -> Transaction:
     return await helpers.create_transaction(session, addresses=[address.address])
+
+
+@pytest.fixture
+async def mempool_transaction(session):
+    _, transaction = await helpers.create_mempool_transaction(session)
+    return transaction
 
 
 @pytest.fixture

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,11 +1,10 @@
-from decimal import Decimal
-import random
-import secrets
-
+from app.models import AddressBalance, Transaction, Block, Address, Output, MemPool
 from sqlalchemy.ext.asyncio import AsyncSession
-
-from app.models import AddressBalance, Transaction, Block, Address, Output
 from app.utils import utcnow, to_timestamp
+from sqlalchemy import select
+from decimal import Decimal
+import secrets
+import random
 
 
 async def create_transaction(
@@ -147,3 +146,53 @@ async def create_address_balance(
     await session.commit()
 
     return address_balance
+
+
+async def create_mempool_transaction(
+    session: AsyncSession,
+    txid: str = None,
+    address: str = None,
+    amount: float = 10.0,
+    currency: str = "PLB",
+) -> tuple[MemPool, dict]:
+    txid = txid or secrets.token_hex(32)
+    address = address or secrets.token_hex(32)
+    shortcut = f"{txid}:0"
+
+    output = {
+        "txid": txid,
+        "shortcut": shortcut,
+        "address": address,
+        "amount": amount,
+        "currency": currency,
+        "timelock": 0,
+        "type": "pubkeyhash",
+        "spent": False,
+        "script": "",
+        "asm": "",
+        "index": 0,
+    }
+
+    transaction = {
+        "txid": txid,
+        "blockhash": None,
+        "timestamp": None,
+        "addresses": [address],
+        "outputs": [output],
+        "inputs": [],
+    }
+
+    mempool = await session.scalar(select(MemPool).limit(1))
+
+    if mempool is None:
+        mempool = MemPool(raw={"transactions": [], "outputs": {}})
+        session.add(mempool)
+
+    raw = dict(mempool.raw)
+    raw["transactions"] = list(raw.get("transactions", [])) + [transaction]
+    raw["outputs"] = {**raw.get("outputs", {}), shortcut: output}
+    mempool.raw = raw
+
+    await session.commit()
+
+    return mempool, transaction

--- a/tests/transactions/test_get_mempool_transaction.py
+++ b/tests/transactions/test_get_mempool_transaction.py
@@ -1,0 +1,24 @@
+from tests.client_requests import transactions
+
+
+async def test_normal(client, block, mempool_transaction):
+    response = await transactions.get_transaction_info(
+        client, mempool_transaction["txid"]
+    )
+    print(response.json())
+    assert response.status_code == 200
+
+    data = response.json()
+    assert data["txid"] == mempool_transaction["txid"]
+    assert data["height"] is None
+    assert data["confirmations"] == 0
+    assert data["coinbase"] is False
+    assert data["coinstake"] is False
+
+
+async def test_not_found(client, block):
+    response = await transactions.get_transaction_info(
+        client, "aabbccdd112233445566778899"
+    )
+    assert response.status_code == 404
+    assert response.json()["code"] == "transactions:not_found"


### PR DESCRIPTION

- Add GET /transactions/{txid} mempool fallback: require_transaction dependency now falls back to mempool lookup when transaction is not found in the database
- Add get_mempool_transaction_by_txid service function that searches MemPool.raw by txid and loads full transaction details via load_mempool_tx_details
- Add POST /address/transactions endpoint accepting {addresses: list[str], currency?: str} returning paginated transaction history for multiple addresses at once
- Add transactions_filters_multi and corresponding count/list service functions using PostgreSQL array overlap operator for efficient multi-address filtering
- Add AddressTransactionsMultiArgs schema in app/address/schemas.py
- Add create_mempool_transaction test helper with all fields required by response schema
- Add mempool_transaction fixture in conftest.py
- Add tests for mempool transaction lookup by txid (normal + not found)
- Add tests for multi-address transaction history (single, multiple distinct addresses, currency filter match/no-match, empty and non-existent addresses)