### PR TITLE
Add wallet info endpoint with blockchain stats

### DIFF
--- a/app/errors.py
+++ b/app/errors.py
@@ -14,6 +14,9 @@ errors = {
     "transactions": {"not-found": ("Transaction not found", 404)},
     "blocks": {"not-found": ("Block not found", 404)},
     "token": {"not-found": ("Token not found", 404)},
+    "wallet": {
+        "inaccessible-node": ["Cannot connect to the node", 502],
+    },
 }
 
 
@@ -33,7 +36,9 @@ def abort_handler(_: Request, exception: Abort | Exception) -> JSONResponse:
     error_message = errors.get(exception.scope, {}).get(
         exception.message, ("Unknown error",)
     )[0]
-    status_code = errors.get(exception.scope, {}).get(exception.message, (None, 400))[1]
+    status_code = errors.get(exception.scope, {}).get(
+        exception.message, (None, 400)
+    )[1]
 
     return JSONResponse(
         status_code=status_code,

--- a/app/wallet/router.py
+++ b/app/wallet/router.py
@@ -1,8 +1,9 @@
 from sqlalchemy.ext.asyncio import AsyncSession
 from fastapi import APIRouter, Body, Depends
 
-from . import service
+from .schemas import WalletInfoResponse
 from app.database import get_session
+from . import service
 
 router = APIRouter(prefix="/wallet", tags=["Wallet"])
 
@@ -13,3 +14,8 @@ async def check_addresses(
     session: AsyncSession = Depends(get_session),
 ) -> list[str]:
     return await service.check_addresses(session, addresses)
+
+
+@router.get("/info", response_model=WalletInfoResponse)
+async def get_wallet_info():
+    return await service.get_wallet_info()

--- a/app/wallet/schemas.py
+++ b/app/wallet/schemas.py
@@ -1,0 +1,14 @@
+from app.schemas import CustomModel
+
+
+class WalletInfoResponse(CustomModel):
+    bestblockhash: str
+    difficulty: int
+    mediantime: int
+    chainwork: str
+    nethash: int
+    headers: int
+    mempool: int
+    reward: int
+    blocks: int
+    chain: str

--- a/app/wallet/service.py
+++ b/app/wallet/service.py
@@ -1,7 +1,11 @@
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy import select
-
+from app.settings import get_settings
+from app.parser import make_request
+from .utils import get_block_reward
 from app.models import Transaction
+from sqlalchemy import select
+from app.errors import Abort
+import typing
 
 
 async def check_addresses(session: AsyncSession, addresses: list[str]):
@@ -18,3 +22,50 @@ async def check_addresses(session: AsyncSession, addresses: list[str]):
             valid_addresses.append(address)
 
     return valid_addresses
+
+
+async def get_wallet_info() -> dict[str, typing.Any]:
+    settings = get_settings()
+    endpoint = settings.blockchain.endpoint
+
+    response = await make_request(
+        endpoint, {"id": "info", "method": "getblockchaininfo", "params": []}
+    )
+    if not response["result"] or response["error"]:
+        raise Abort("wallet", "inaccessible-node")
+
+    blockchain_info: dict[str, typing.Any] = response["result"]
+
+    response = await make_request(
+        endpoint, {"id": "mempool", "method": "getmempoolinfo", "params": []}
+    )
+    if not response["result"] or response["error"]:
+        raise Abort("wallet", "inaccessible-node")
+
+    mempool_info = response["result"]
+
+    response = await make_request(
+        endpoint,
+        {
+            "id": "nethash",
+            "method": "getnetworkhashps",
+            "params": [120, blockchain_info["blocks"]],
+        },
+    )
+    if not response["result"] or response["error"]:
+        raise Abort("wallet", "inaccessible-node")
+
+    nethash = int(response["result"])
+
+    return {
+        "chain": blockchain_info["chain"],
+        "blocks": blockchain_info["blocks"],
+        "headers": blockchain_info["headers"],
+        "bestblockhash": blockchain_info["bestblockhash"],
+        "difficulty": blockchain_info["difficulty"],
+        "mediantime": blockchain_info["mediantime"],
+        "chainwork": blockchain_info["chainwork"],
+        "reward": get_block_reward(blockchain_info["blocks"]),
+        "mempool": mempool_info["size"],
+        "nethash": nethash,
+    }

--- a/app/wallet/utils.py
+++ b/app/wallet/utils.py
@@ -1,0 +1,5 @@
+def get_block_reward(height: int) -> int:
+    halvings = height // 525960
+    if halvings >= 10:
+        return 0
+    return int(4 * 10**8 // (2**halvings))


### PR DESCRIPTION
- Add GET /wallet/info endpoint returning blockchain and network stats
- Implement get_wallet_info service fetching data from blockchain node
- Add WalletInfoResponse schema with chain, blocks, difficulty, nethash, etc.
- Add get_block_reward utility with halving logic (every 525960 blocks)
- Add wallet/inaccessible-node error for node connection failures