### PR TITLE
Refactor wallet info to use database instead of node RPC calls

### DIFF
--- a/app/errors.py
+++ b/app/errors.py
@@ -15,7 +15,7 @@ errors = {
     "blocks": {"not-found": ("Block not found", 404)},
     "token": {"not-found": ("Token not found", 404)},
     "wallet": {
-        "inaccessible-node": ["Cannot connect to the node", 502],
+        "not-synchronized": ("Not synchronized", 400),
     },
 }
 

--- a/app/wallet/router.py
+++ b/app/wallet/router.py
@@ -17,5 +17,5 @@ async def check_addresses(
 
 
 @router.get("/info", response_model=WalletInfoResponse)
-async def get_wallet_info():
-    return await service.get_wallet_info()
+async def get_wallet_info(session: AsyncSession = Depends(get_session)):
+    return await service.get_wallet_info(session)

--- a/app/wallet/schemas.py
+++ b/app/wallet/schemas.py
@@ -3,12 +3,7 @@ from app.schemas import CustomModel
 
 class WalletInfoResponse(CustomModel):
     bestblockhash: str
-    difficulty: int
     mediantime: int
-    chainwork: str
-    nethash: int
-    headers: int
     mempool: int
     reward: int
     blocks: int
-    chain: str

--- a/app/wallet/service.py
+++ b/app/wallet/service.py
@@ -1,8 +1,5 @@
+from app.models import Transaction, Block, MemPool
 from sqlalchemy.ext.asyncio import AsyncSession
-from app.settings import get_settings
-from app.parser import make_request
-from .utils import get_block_reward
-from app.models import Transaction
 from sqlalchemy import select
 from app.errors import Abort
 import typing
@@ -24,48 +21,23 @@ async def check_addresses(session: AsyncSession, addresses: list[str]):
     return valid_addresses
 
 
-async def get_wallet_info() -> dict[str, typing.Any]:
-    settings = get_settings()
-    endpoint = settings.blockchain.endpoint
-
-    response = await make_request(
-        endpoint, {"id": "info", "method": "getblockchaininfo", "params": []}
+async def get_wallet_info(session: AsyncSession) -> dict[str, typing.Any]:
+    bestblock = await session.scalar(
+        select(Block).order_by(Block.height.desc()).limit(1)
     )
-    if not response["result"] or response["error"]:
-        raise Abort("wallet", "inaccessible-node")
+    if not bestblock:
+        raise Abort("wallet", "not-synchronized")
 
-    blockchain_info: dict[str, typing.Any] = response["result"]
+    mempool = await session.scalar(select(MemPool))
 
-    response = await make_request(
-        endpoint, {"id": "mempool", "method": "getmempoolinfo", "params": []}
-    )
-    if not response["result"] or response["error"]:
-        raise Abort("wallet", "inaccessible-node")
-
-    mempool_info = response["result"]
-
-    response = await make_request(
-        endpoint,
-        {
-            "id": "nethash",
-            "method": "getnetworkhashps",
-            "params": [120, blockchain_info["blocks"]],
-        },
-    )
-    if not response["result"] or response["error"]:
-        raise Abort("wallet", "inaccessible-node")
-
-    nethash = int(response["result"])
+    mempool_size = 0
+    if mempool is not None:
+        mempool_size = len(mempool.raw["transactions"])
 
     return {
-        "chain": blockchain_info["chain"],
-        "blocks": blockchain_info["blocks"],
-        "headers": blockchain_info["headers"],
-        "bestblockhash": blockchain_info["bestblockhash"],
-        "difficulty": blockchain_info["difficulty"],
-        "mediantime": blockchain_info["mediantime"],
-        "chainwork": blockchain_info["chainwork"],
-        "reward": get_block_reward(blockchain_info["blocks"]),
-        "mempool": mempool_info["size"],
-        "nethash": nethash,
+        "bestblockhash": bestblock.blockhash,
+        "mediantime": bestblock.timestamp,
+        "blocks": bestblock.height,
+        "reward": int(bestblock.reward),
+        "mempool": mempool_size,
     }


### PR DESCRIPTION
Replace direct blockchain node RPC calls in get_wallet_info with database queries.
- Query best block from Block table instead of getblockchaininfo
- Query mempool size from MemPool table instead of getmempoolinfo
- Remove nethash, difficulty, chainwork, headers, chain fields from response
- Add not-synchronized error when no blocks found in database
