### PR TITLE
Add POST /address/transactions/mempool endpoint with tests

### DIFF
--- a/app/address/router.py
+++ b/app/address/router.py
@@ -1,5 +1,4 @@
 from app.utils import pagination, paginated_response
-from .schemas import AddressTransactionsMultiArgs
 from sqlalchemy.ext.asyncio import AsyncSession
 from fastapi import APIRouter, Depends
 from app.dependencies import get_page
@@ -11,6 +10,10 @@ from app.schemas import (
     OutputPaginatedResponse,
     TransactionResponse,
     BalanceResponse,
+)
+from .schemas import (
+    AddressTransactionsMultiMempoolArgs,
+    AddressTransactionsMultiArgs,
 )
 
 router = APIRouter(prefix="/address", tags=["Addresses"])
@@ -29,6 +32,26 @@ async def list_transactions_multi(
     )
     items = await service.list_transactions_multi(
         session, args.addresses, args.currency, limit, offset
+    )
+
+    return paginated_response(items, total, page, limit)
+
+
+@router.post(
+    "/transactions/mempool", response_model=TransactionPaginatedResponse
+)
+async def list_transactions_multi_mempool(
+    args: AddressTransactionsMultiMempoolArgs,
+    session: AsyncSession = Depends(get_session),
+    page: int = Depends(get_page),
+):
+    limit, offset = pagination(page)
+
+    total = await service.count_transactions_multi_mempool(
+        session, args.addresses
+    )
+    items = await service.list_transactions_multi_mempool(
+        session, args.addresses, limit, offset
     )
 
     return paginated_response(items, total, page, limit)

--- a/app/address/schemas.py
+++ b/app/address/schemas.py
@@ -4,3 +4,7 @@ from app.schemas import CustomModel
 class AddressTransactionsMultiArgs(CustomModel):
     addresses: list[str]
     currency: str | None = None
+
+
+class AddressTransactionsMultiMempoolArgs(CustomModel):
+    addresses: list[str]

--- a/app/address/service.py
+++ b/app/address/service.py
@@ -1,6 +1,6 @@
 import typing
 
-from sqlalchemy import Select, select, func, ScalarResult
+from sqlalchemy import Select, select, func, ScalarResult, text
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models import Output, Transaction, AddressBalance, Address, MemPool
@@ -144,6 +144,20 @@ async def count_transactions_multi(
     )
 
 
+async def count_transactions_multi_mempool(
+    session: AsyncSession, addresses: list[str]
+) -> int:
+    return await session.scalar(
+        text("""
+        SELECT COUNT(1)
+        FROM service_mempool,
+            jsonb_array_elements(raw->'transactions') AS tx
+        WHERE tx->'addresses' ?| :addresses
+    """),
+        {"addresses": addresses},
+    )
+
+
 async def list_transactions(
     session: AsyncSession,
     address: str,
@@ -192,6 +206,35 @@ async def list_transactions_multi(
         transactions.append(
             await load_tx_details(session, transaction, latest_block)
         )
+
+    return transactions
+
+
+async def list_transactions_multi_mempool(
+    session: AsyncSession,
+    addresses: list[str],
+    limit: int,
+    offset: int,
+) -> list[dict[str, typing.Any]]:
+    stmt = text("""
+        SELECT tx
+        FROM service_mempool,
+            jsonb_array_elements(raw->'transactions') AS tx
+        WHERE tx->'addresses' ?| :addresses
+        ORDER BY (tx->>'created')::bigint DESC
+        OFFSET :offset
+        LIMIT :limit
+    """)
+
+    txs = await session.scalars(
+        stmt, {"addresses": addresses, "limit": limit, "offset": offset}
+    )
+    outputs = await session.scalar(select(MemPool.raw.op("->")("outputs")))
+    assert outputs is not None
+
+    transactions: list[dict[str, typing.Any]] = [
+        await load_mempool_tx_details(session, tx, outputs) for tx in txs
+    ]
 
     return transactions
 

--- a/tests/address/test_list_address_transactions_multi_mempool.py
+++ b/tests/address/test_list_address_transactions_multi_mempool.py
@@ -1,0 +1,82 @@
+from tests.client_requests import addresses
+from tests import helpers
+import secrets
+
+
+async def test_normal(client, mempool_transaction):
+    response = await addresses.post_address_transactions_multi_mempool(
+        client=client,
+        addresses=mempool_transaction["addresses"],
+    )
+    print(response.json())
+    assert response.status_code == 200
+
+    assert response.json()["pagination"] == {"total": 1, "pages": 1, "page": 1}
+
+    transaction_data = response.json()["list"][0]
+    assert transaction_data["txid"] == mempool_transaction["txid"]
+    assert transaction_data["height"] is None
+    assert transaction_data["confirmations"] == 0
+
+
+async def test_no_matching_addresses(client, mempool_transaction, session):
+    # mempool_transaction ensures a MemPool record exists
+    other_address = secrets.token_hex(20)
+
+    response = await addresses.post_address_transactions_multi_mempool(
+        client=client,
+        addresses=[other_address],
+    )
+    print(response.json())
+    assert response.status_code == 200
+
+    assert response.json()["pagination"] == {"total": 0, "pages": 0, "page": 1}
+    assert response.json()["list"] == []
+
+
+async def test_multiple_addresses(client, session):
+    addr1 = secrets.token_hex(20)
+    addr2 = secrets.token_hex(20)
+
+    _, tx1 = await helpers.create_mempool_transaction(session, address=addr1)
+    _, tx2 = await helpers.create_mempool_transaction(session, address=addr2)
+
+    # Each address alone returns only its own transaction
+    response1 = await addresses.post_address_transactions_multi_mempool(
+        client=client, addresses=[addr1]
+    )
+    assert response1.status_code == 200
+    assert response1.json()["pagination"]["total"] == 1
+    assert response1.json()["list"][0]["txid"] == tx1["txid"]
+
+    response2 = await addresses.post_address_transactions_multi_mempool(
+        client=client, addresses=[addr2]
+    )
+    assert response2.status_code == 200
+    assert response2.json()["pagination"]["total"] == 1
+    assert response2.json()["list"][0]["txid"] == tx2["txid"]
+
+    # Both addresses together return both transactions
+    response = await addresses.post_address_transactions_multi_mempool(
+        client=client, addresses=[addr1, addr2]
+    )
+    print(response.json())
+    assert response.status_code == 200
+    assert response.json()["pagination"] == {"total": 2, "pages": 1, "page": 1}
+
+    txids = {tx["txid"] for tx in response.json()["list"]}
+    assert tx1["txid"] in txids
+    assert tx2["txid"] in txids
+
+
+async def test_empty_addresses(client, mempool_transaction):
+    # mempool_transaction ensures a MemPool record exists
+    response = await addresses.post_address_transactions_multi_mempool(
+        client=client,
+        addresses=[],
+    )
+    print(response.json())
+    assert response.status_code == 200
+
+    assert response.json()["pagination"] == {"total": 0, "pages": 0, "page": 1}
+    assert response.json()["list"] == []

--- a/tests/client_requests/addresses.py
+++ b/tests/client_requests/addresses.py
@@ -57,3 +57,15 @@ async def post_address_transactions_multi(
         json=body,
         query_string={"page": page},
     )
+
+
+async def post_address_transactions_multi_mempool(
+    client: TestClient,
+    addresses: list[str],
+    page: int = 1,
+) -> Response:
+    return await client.post(
+        "/address/transactions/mempool",
+        json={"addresses": addresses},
+        query_string={"page": page},
+    )


### PR DESCRIPTION
- Add AddressTransactionsMultiMempoolArgs schema (addresses-only, no currency filter)
- Add count_transactions_multi_mempool and list_transactions_multi_mempool service functions using raw SQL with jsonb_array_elements
- Add list_transactions_multi_mempool router endpoint with pagination
- Add post_address_transactions_multi_mempool test client helper
- Add tests: normal, no matching addresses, multiple addresses, empty addresses list